### PR TITLE
Add support for local storage with or without explicit backend mounting.

### DIFF
--- a/etc/migmount.conf
+++ b/etc/migmount.conf
@@ -12,6 +12,13 @@ declare -xr MIG_TMPFS_BASE="${STORAGE_BASE}/mnt/tmpfs"
 declare -xr MIG_DISKIMG_BASE="${STORAGE_BASE}/mnt/diskimg"
 
 ###
+# Local setup
+###
+declare -xr LOCAL_BACKEND_OPTS="noatime"
+declare -xr LOCAL_BACKEND_SRC=""
+declare -xr LOCAL_BACKEND_DEST=""
+
+###
 # Lustre setup
 ###
 declare -xr LUSTRE_BACKEND_FQDN=""
@@ -54,7 +61,6 @@ declare -xA MIG_BIND_STORAGE=();
 ###
 # Services to start after mount
 ###
-
 declare -xa POST_MOUNT_SERVICES=("")
 
 ###

--- a/sbin/migmount.sh
+++ b/sbin/migmount.sh
@@ -55,6 +55,7 @@ usage() {
     # Usage help for mount
     echo "Usage: $__scriptname__ [OPTIONS] action"
     echo "Where action is one of the following:"
+    echo "  local"
     echo "  gluster"
     echo "  lustre"
     echo "  lustre-gocryptfs"
@@ -114,7 +115,11 @@ main() {
     declare cmd=""
     parse_input "${@}"
     info "$__scriptname__ $__action__"
-    if [ "$__action__" == "gluster" ]; then
+    if [ "$__action__" == "local" ]; then
+        cmd="mount_local"
+        execute_force "$cmd"
+        ret=$?
+    elif [ "$__action__" == "gluster" ]; then
         cmd="mount_gluster"
         execute_force "$cmd"
         ret=$?

--- a/sbin/migumount.sh
+++ b/sbin/migumount.sh
@@ -55,6 +55,7 @@ usage() {
     # Usage help for mount
     echo "Usage: $__scriptname__ [OPTIONS] action"
     echo "Where action is one of the following:"
+    echo "  local"
     echo "  gluster"
     echo "  lustre"
     echo "  lustre-gocryptfs"
@@ -118,7 +119,11 @@ main() {
     ret=$?
     iferror $ret "Failed to stop services: ${PRE_UMOUNT_SERVICES}"
     [ "$ret" -ne 0 ] && [ "$__FORCE__" -eq 0 ] && return $ret
-    if [ "$__action__" == "gluster" ]; then
+    if [ "$__action__" == "local" ]; then
+        cmd="umount_local"
+        execute_force "$cmd"
+        ret=$?
+    elif [ "$__action__" == "gluster" ]; then
         cmd="umount_gluster"
         execute_force "$cmd"
         ret=$?


### PR DESCRIPTION
Add support for local storage with or without explicit backend re-mounting.
Adds a new `local` mount/umount target with corresponding new `LOCAL_BACKEND_X` variables.
Leaving them empty should have no effect but setting `LOCAL_BACKEND_SRC` and `LOCAL_BACKEND_DEST` to the same fs path will use that path  as local storage without any explicit re-mounting. Setting both but with SRC different from DEST is meant for mounting SRC onto DEST.
All the usual bind mounts will be managed independently of the those variables.

Work-in-Progress with testing at bench.